### PR TITLE
Centralised token refresh mechanism 

### DIFF
--- a/NimbleTechTest.xcodeproj/project.pbxproj
+++ b/NimbleTechTest.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1068FA8CC613D844A0D81437 /* Pods_NimbleTechTest_NimbleTechTestUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D871F550CB0B73F44A16A14 /* Pods_NimbleTechTest_NimbleTechTestUITests.framework */; };
 		1D8D2E4503FDF878CF38978D /* Pods_NimbleTechTestTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D9BDC0869D382D5EB8E448F8 /* Pods_NimbleTechTestTests.framework */; };
 		6EE2C0D96233243D61A45910 /* Pods_NimbleTechTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACD53EE4CF4A65AB84810251 /* Pods_NimbleTechTest.framework */; };
+		A2903F9B2AFF338F00749443 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2903F9A2AFF338F00749443 /* TokenManager.swift */; };
 		CB1530372AF2D92C0051FCA5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1530362AF2D92C0051FCA5 /* AppDelegate.swift */; };
 		CB1530392AF2D92C0051FCA5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1530382AF2D92C0051FCA5 /* SceneDelegate.swift */; };
 		CB15303B2AF2D92C0051FCA5 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB15303A2AF2D92C0051FCA5 /* LoginViewController.swift */; };
@@ -69,6 +70,7 @@
 		6DEB1000AA29B54F0EC0B5B6 /* Pods-NimbleTechTest-NimbleTechTestUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleTechTest-NimbleTechTestUITests.release.xcconfig"; path = "Target Support Files/Pods-NimbleTechTest-NimbleTechTestUITests/Pods-NimbleTechTest-NimbleTechTestUITests.release.xcconfig"; sourceTree = "<group>"; };
 		74D76ED487EA1CD06443D28E /* Pods-NimbleTechTestTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleTechTestTests.release.xcconfig"; path = "Target Support Files/Pods-NimbleTechTestTests/Pods-NimbleTechTestTests.release.xcconfig"; sourceTree = "<group>"; };
 		98A6F53B8422A322039866F9 /* Pods-NimbleTechTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleTechTest.release.xcconfig"; path = "Target Support Files/Pods-NimbleTechTest/Pods-NimbleTechTest.release.xcconfig"; sourceTree = "<group>"; };
+		A2903F9A2AFF338F00749443 /* TokenManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenManager.swift; sourceTree = "<group>"; };
 		ACD53EE4CF4A65AB84810251 /* Pods_NimbleTechTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleTechTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C645D82DAFF087C4D68943B0 /* Pods-NimbleTechTest-NimbleTechTestUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleTechTest-NimbleTechTestUITests.debug.xcconfig"; path = "Target Support Files/Pods-NimbleTechTest-NimbleTechTestUITests/Pods-NimbleTechTest-NimbleTechTestUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		CB1530332AF2D92C0051FCA5 /* NimbleTechTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NimbleTechTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -281,6 +283,7 @@
 				CB1530682AF3E1EB0051FCA5 /* ApiManager.swift */,
 				CB87D9312AF66126001CA7F7 /* LoadingButton.swift */,
 				CB3942052AF840B800B9D287 /* PasswordTextField.swift */,
+				A2903F9A2AFF338F00749443 /* TokenManager.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -547,6 +550,7 @@
 				CB15306B2AF428440051FCA5 /* TokenResponseModel.swift in Sources */,
 				CB1530372AF2D92C0051FCA5 /* AppDelegate.swift in Sources */,
 				CB3942062AF840B800B9D287 /* PasswordTextField.swift in Sources */,
+				A2903F9B2AFF338F00749443 /* TokenManager.swift in Sources */,
 				CBAE47DB2AF57FEE00AC4665 /* Launcher.swift in Sources */,
 				CBAE47D12AF541B000AC4665 /* HomeViewController.swift in Sources */,
 				CB3942002AF8380100B9D287 /* ForgotPasswordViewController.swift in Sources */,

--- a/NimbleTechTest/Helper/ApiManager.swift
+++ b/NimbleTechTest/Helper/ApiManager.swift
@@ -36,8 +36,7 @@ struct defaultKeys {
 }
 
 class ApiManager {
-    private let keychain = Keychain(service: "com.akazad.app.refreshToken")
-	private var isRefreshingToken = false
+    private var tokenManager = TokenManager()
     
 	func callApi<T: Decodable>(urlString: String,
 							   method: HTTPMethod,
@@ -47,124 +46,51 @@ class ApiManager {
 		func updateAuthorizationHeader(_ accessToken: String) -> HTTPHeaders {
 			return HTTPHeaders(["Authorization": "Bearer \(accessToken)"])
 		}
-
-		AF.request(urlString, method: method, parameters: parameters, encoding: JSONEncoding.default, headers: updateAuthorizationHeader(getAccessToken()))
+		
+		AF.request(urlString, method: method, parameters: parameters, encoding: JSONEncoding.default, headers: updateAuthorizationHeader(tokenManager.getAccessToken()))
 			.validate()
 			.responseDecodable(of: T.self) { [weak self] response in
 				guard let self = self else { return }
-
+				
 				switch response.result {
-				case .success(let decodedObject):
-					completion(.success(decodedObject))
-
-				case .failure(let error):
-					print("error: \(error)")
-					if let statusCode = response.response?.statusCode, statusCode == 401 {
-						// Check if token refresh is not already in progress
-						guard !self.isRefreshingToken else {
-							completion(.failure(.accessTokenExpired))
-							return
+					case .success(let decodedObject):
+						completion(.success(decodedObject))
+						
+					case .failure(let error):
+						print("error: \(error)")
+						
+						if let statusCode = response.response?.statusCode, statusCode == 401 {
+							self.handleTokenExpiration(urlString: urlString, method: method, parameters: parameters, completion: completion)
+						} else {
+							completion(.failure(.networkError))
 						}
-
-						// Mark that token refresh is in progress
-						self.isRefreshingToken = true
-
-						self.refreshAccessToken { result in
-							// Mark that token refresh is completed
-							self.isRefreshingToken = false
-
-							switch result {
-							case .success:
-								// Retry the original request with the new access token
-								self.callApi(urlString: urlString, method: method, parameters: parameters, completion: completion)
-
-							case .failure(let refreshError):
-								print("Token refresh failed with error: \(refreshError)")
-								completion(.failure(.accessTokenExpired))
-							}
-						}
-					} else {
-						completion(.failure(.networkError))
-					}
-				}
-			}
-	}
-
-	func refreshAccessToken(completion: @escaping (Result<Void, APIError>) -> Void) {
-		guard let refreshToken = try? keychain.get(defaultKeys.refreshTokenKey) else {
-			completion(.failure(.accessTokenExpired))
-			return
-		}
-		
-		let refreshTokenUrl = Constants.baseUrl.rawValue
-		
-		struct RefreshTokenResponse: Decodable {
-			let data: TokenResponse?
-		}
-		
-		let parameters: Parameters = [
-			"grant_type": GrantType.refreshToken.rawValue,
-			"refresh_token": refreshToken,
-			"client_id": Constants.clientId.rawValue,
-			"client_secret": Constants.clientSecret.rawValue
-		]
-		
-		AF.request(refreshTokenUrl, method: .post, parameters: parameters, encoding: JSONEncoding.default)
-			.validate()
-			.responseDecodable(of: RefreshTokenResponse.self) { response in
-				switch response.result {
-				case .success(let refreshTokenResponse):
-					if let tokenResponse = refreshTokenResponse.data {
-						self.saveAccessToken(tokenResponse.attributes?.accessToken ?? "")
-						self.saveRefreshToken(tokenResponse.attributes?.refreshToken ?? "")
-						completion(.success(()))
-					} else {
-						completion(.failure(.parsingError))
-					}
-					
-				case .failure:
-					completion(.failure(.networkError))
+						
 				}
 			}
 	}
 	
-    func saveRefreshToken(_ token: String) {
-        do {
-            try keychain.set(token, key: defaultKeys.refreshTokenKey)
-        } catch {
-            print("Error saving refresh token to keychain: \(error)")
-        }
-    }
-    
-    func getRefreshToken() -> String {
-        var refreshToken = ""
-        do {
-            refreshToken = try keychain.getString(defaultKeys.refreshTokenKey) ?? ""
-        } catch {
-            print("Error saving refresh token to keychain: \(error)")
-        }
-        
-        return refreshToken
-    }
-    
-    func saveAccessToken(_ token: String) {
-        do {
-            try keychain.set(token, key: defaultKeys.accessTokenKey)
-        } catch {
-            print("Error saving access token to keychain: \(error)")
-        }
-    }
-    
-    func getAccessToken() -> String {
-        var accessToken = ""
-        do {
-            accessToken = try keychain.getString(defaultKeys.accessTokenKey) ?? ""
-        } catch {
-            print("Error getting access token")
-        }
-        
-        return accessToken
-    }
+	private func handleTokenExpiration<T: Decodable>(urlString: String, method: HTTPMethod,parameters: Parameters?,completion: @escaping (Result<T, APIError>) -> Void) {
+		guard !tokenManager.isRefreshingToken else {
+			completion(.failure(.accessTokenExpired))
+			return
+		}
+		
+		tokenManager.isRefreshingToken = true
+		
+		tokenManager.refreshAccessToken { result in
+			self.tokenManager.isRefreshingToken = false
+			
+			switch result {
+				case .success:
+					// Retry the original request with the new access token
+					self.callApi(urlString: urlString, method: method, parameters: parameters, completion: completion)
+					
+				case .failure(let refreshError):
+					print("Token refresh failed with error: \(refreshError)")
+					completion(.failure(.accessTokenExpired))
+			}
+		}
+	}
 }
 
 

--- a/NimbleTechTest/Helper/TokenManager.swift
+++ b/NimbleTechTest/Helper/TokenManager.swift
@@ -1,0 +1,91 @@
+//
+//  TokenManager.swift
+//  NimbleTechTest
+//
+//  Created by Abul Kalam Azad on 11/11/23.
+//
+
+import Foundation
+import KeychainAccess
+import Alamofire
+
+class TokenManager {
+	private let keychain = Keychain(service: "com.akazad.app.refreshToken")
+	var isRefreshingToken = false
+
+	func refreshAccessToken(completion: @escaping (Result<Void, APIError>) -> Void) {
+		guard let refreshToken = try? keychain.get(defaultKeys.refreshTokenKey) else {
+			completion(.failure(.accessTokenExpired))
+			return
+		}
+
+		let refreshTokenUrl = Constants.baseUrl.rawValue
+
+		struct RefreshTokenResponse: Decodable {
+			let data: TokenResponse?
+		}
+
+		let parameters: Parameters = [
+			"grant_type": GrantType.refreshToken.rawValue,
+			"refresh_token": refreshToken,
+			"client_id": Constants.clientId.rawValue,
+			"client_secret": Constants.clientSecret.rawValue
+		]
+
+		AF.request(refreshTokenUrl, method: .post, parameters: parameters, encoding: JSONEncoding.default)
+			.validate()
+			.responseDecodable(of: RefreshTokenResponse.self) { response in
+				switch response.result {
+				case .success(let refreshTokenResponse):
+					if let tokenResponse = refreshTokenResponse.data {
+						self.saveAccessToken(tokenResponse.attributes?.accessToken ?? "")
+						self.saveRefreshToken(tokenResponse.attributes?.refreshToken ?? "")
+						completion(.success(()))
+					} else {
+						completion(.failure(.parsingError))
+					}
+
+				case .failure:
+					completion(.failure(.networkError))
+				}
+			}
+	}
+
+	private func saveRefreshToken(_ token: String) {
+		do {
+			try keychain.set(token, key: defaultKeys.refreshTokenKey)
+		} catch {
+			print("Error saving refresh token to keychain: \(error)")
+		}
+	}
+
+	private func saveAccessToken(_ token: String) {
+		do {
+			try keychain.set(token, key: defaultKeys.accessTokenKey)
+		} catch {
+			print("Error saving access token to keychain: \(error)")
+		}
+	}
+	
+	func getRefreshToken() -> String {
+		var refreshToken = ""
+		do {
+			refreshToken = try keychain.getString(defaultKeys.refreshTokenKey) ?? ""
+		} catch {
+			print("Error saving refresh token to keychain: \(error)")
+		}
+		
+		return refreshToken
+	}
+	
+	func getAccessToken() -> String {
+		var accessToken = ""
+		do {
+			accessToken = try keychain.getString(defaultKeys.accessTokenKey) ?? ""
+		} catch {
+			print("Error getting access token")
+		}
+		
+		return accessToken
+	}
+}

--- a/NimbleTechTest/Home/HomeViewController.swift
+++ b/NimbleTechTest/Home/HomeViewController.swift
@@ -11,7 +11,7 @@ import Kingfisher
 
 class HomeViewController: UIViewController {
     
-    var viewModel: HomeViewModelProtocol!
+    var viewModel: HomeViewModel!
     var router: HomeRouter!
         
     private var scrollview = UIScrollView()
@@ -83,23 +83,13 @@ class HomeViewController: UIViewController {
         showLoadingAnimation()
         
         // Attempt to load cached data
-        if let cachedSurveys = UserDefaults.standard.data(forKey: defaultKeys.cachedSurveyData) {
-            if let decodedSurveys = try? JSONDecoder().decode([SurveyList].self, from: cachedSurveys) {
-                self.viewModel.responseData = decodedSurveys
-                self.updateUI()
-            }
-        }
+		viewModel.loadCachedSurveys()
         
         viewModel.fetchServeyListFromAPI(pageNumber: page, pageSize: size) { [weak self] in
             DispatchQueue.main.async {
                 // Hide loading animation
                 self?.hideLoadingAnimation()
                 self?.updateUI()
-                
-                // Cache the fetched data
-                if let surveysData = try? JSONEncoder().encode(self?.viewModel.responseData) {
-                    UserDefaults.standard.set(surveysData, forKey: defaultKeys.cachedSurveyData)
-                }
                 
                 // End the refresh control
                 self?.refreshControl.endRefreshing()

--- a/NimbleTechTest/Login/LoginViewController.swift
+++ b/NimbleTechTest/Login/LoginViewController.swift
@@ -60,16 +60,17 @@ class LoginViewController: UIViewController {
                 passwordTextField.forgotPasswordLabel.addGestureRecognizer(tapGesture)
         loginButton.addTarget(self, action: #selector(onLoginButtonTap), for: .touchUpInside)
     }
-    
-    @objc func onLoginButtonTap() {
-        self.view.endEditing(true)
-        loginButton.showLoading()
-		
-		viewModel.validateAndLogin(email: emailTextField.text, password: passwordTextField.text)
-    }
 }
 
+//MARK: Handle Tap
 extension LoginViewController {
+	@objc func onLoginButtonTap() {
+		self.view.endEditing(true)
+		loginButton.showLoading()
+		
+		viewModel.validateAndLogin(email: emailTextField.text, password: passwordTextField.text)
+	}
+	
     @objc private func forgotPasswordLabelTapped() {
         // Handle "Forgot Password" action
         self.router.perform(.forgotPassword, from: self)

--- a/NimbleTechTest/Login/LoginViewModel.swift
+++ b/NimbleTechTest/Login/LoginViewModel.swift
@@ -161,30 +161,14 @@ class LoginViewModel {
 			guard let self = self else { return }
 			
 			switch result {
-				case .success(let response):
-					self.apiManager.saveAccessToken(response.data?.attributes?.accessToken ?? "")
-					self.apiManager.saveRefreshToken(response.data?.attributes?.refreshToken ?? "")
+				case .success(_):
 					DispatchQueue.main.async { [weak self] in
 						self?.onLoginSuccess?()
 					}
-				case .failure(let error):
-					if error == .accessTokenExpired {
-						self.handleAccessTokenExpired()
-					}
+				case .failure(_):
 					DispatchQueue.main.async { [weak self] in
 						self?.onLoginFailure?("Login failed, please try again!")
 					}
-			}
-		}
-	}
-	
-	func handleAccessTokenExpired() {
-		apiManager.refreshAccessToken { result in
-			switch result {
-				case .success:
-					print("successfully refreshed access token")
-				case .failure:
-					print("failed to refresh access token")
 			}
 		}
 	}


### PR DESCRIPTION
Enhance authentication flow to handle token expiration more gracefuly. Instead of relying solely on the login API to trigger token refresh, implemented a centralized refresh token mechanism. This ensures that token refresh occurs not only during login but also when making subsequent API calls after the token has expired.